### PR TITLE
Kick off the initial timeline doc 🕰️

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # almanac
 Reference repository composed of timelines, lists and various other informative items related to the field of continuous delivery
+
+* [Timeline](timeline.md)

--- a/timeline.md
+++ b/timeline.md
@@ -1,0 +1,23 @@
+# Continuous Delivery Terminology Timeline
+
+The purpose of this doc is to record the timeline of when important terminology in
+the Continous Delivery came into being.
+
+This is not meant to be the definitivie definitions of each of these terms (watch
+this repo!)
+
+This is meant to be a living document: if you have additional information on the
+origins of these phrases, [please open a PR](CONTRIBUTING.md)!
+
+\* Canonical indicates that these works were particularly impactful on the narrative
+   in the CD community, e.g. created the phrases we use today
+
+| Canonical\* | When | What | Source (if needed) |
+| ----------- | ---- |------|--------------------|
+|    | July 2019 | [CDF faq defines continuous delivery](https://github.com/cdfoundation/faq#what-is-continuous-delivery-cd) | [cdfoundation/faq](https://github.com/cdfoundation/faq/commit/e1c2ea472284422ff300c948f13fb37de528d926)|
+|    | July 2013 | [Martin Fowler defines Continuous Delivery](https://www.martinfowler.com/bliki/ContinuousDelivery.html) ||
+| ⭐ | July 2010   | [Continuous Delivery by Jez Humble and David Farley](https://www.oreilly.com/library/view/continuous-delivery-reliable/9780321670250/) ||
+|    | Feb 2010 | [Continuous Delivery](https://continuousdelivery.com/2010/02/continuous-delivery/) ||
+| ⭐ | Feb 2009 | [Continuous Deployment](http://timothyfitz.com/2009/02/08/continuous-deployment/) ||
+| ⭐ | June 2007  | [Continuous Integration: Improving Software Quality and Reducing Risk](https://www.oreilly.com/library/view/continuous-integration-improving/9780321336385/) || 
+


### PR DESCRIPTION
[SIG interoperability](https://github.com/cdfoundation/sig-interoperability) started working on a white paper, and found themselves wanting to define terms they used such as "continuous delivery" and "CI/CD". The call to
define these terms brought so much feedback that it has been split into [a separate document](https://docs.google.com/document/d/1IUSmgtw5eC2JwyfiX7IPK3twl3MSjWAsmCKmJ6Y5z-w/edit#) in which we are continuing to iterate on these definitions.

In order to help move this discussion forward, I think it's useful to be able to look back at the history of these terms and how they came into being.

The document added in this commit lists some of the impactful sources of these terms.

I've gone back and forth on what to include, and whether or not it makes sense to identify some of these sources as more impactful than others (i.e. "canonical"). I also initially included every blog post and book I encountered on this topic and am still not sure if it makes sense to track that here. I'm leaning towards including it, but maybe in a separate table or doc?

Anyway I want to keep adding to this!
* Via [this blog post by @jezhumble from 2010](https://continuousdelivery.com/2010/02/continuous-delivery/) I've discovered that the phrase "continuous delivery" was inspired by the principles behind the Agile Manifesto, so I want to include the Agile Manifesto in this list as well
* I want to include more about Continuous integration (discovered via [a series of blog posts by circleci](https://circleci.com/blog/a-brief-history-of-devops-part-iii-automated-testing-and-continuous-integration/)).

(I also discovered via [a @jezhumble blog post](https://continuousdelivery.com/2010/08/continuous-delivery-vs-continuous-deployment/) that "Continuous Deployment" actually came first - before "continuous delivery" -  which was fascinating!!)

Anyway I hope this is a good starting point!!

@salaboy @tracymiranda @tequilarista