### PR TITLE
Add CI and CI/CD to the timeline ⌛

### DIFF
--- a/timeline.md
+++ b/timeline.md
@@ -15,6 +15,7 @@ origins of these phrases, [please open a PR](CONTRIBUTING.md)!
 | Canonical\* | When | What | Terms | Source (if needed) |
 | ----------- | ---- | ---- | ----- |--------------------|
 |    | July 2019 | [CDF faq defines continuous delivery](https://github.com/cdfoundation/faq#what-is-continuous-delivery-cd) | Continuous Delivery, Continuous Integration | [cdfoundation/faq](https://github.com/cdfoundation/faq/commit/e1c2ea472284422ff300c948f13fb37de528d926)|
+|    | March 2019 | [CDF created](https://cd.foundation/announcement/2019/03/12/the-linux-foundation-announces-new-foundation-to-support-continuous-delivery-collaboration/) | | |
 |    | Dec 2016 | [First Wikipedia entry for CI/CD](https://en.wikipedia.org/w/index.php?title=CI/CD&oldid=756752283) | CI/CD | |
 |    | July 2014 | [Earliest article attempting to explain the origin of "CI/CD"](https://blogs.oracle.com/ravello/continuous-integration-deployment-test-automation) | CI/CD | |
 |    | 2014 | [CI/CD starts appearing as a search term](https://trends.google.com/trends/explore?date=all&q=ci%2Fcd) | CI/CD | |

--- a/timeline.md
+++ b/timeline.md
@@ -12,12 +12,17 @@ origins of these phrases, [please open a PR](CONTRIBUTING.md)!
 \* Canonical indicates that these works were particularly impactful on the narrative
    in the CD community, e.g. created the phrases we use today
 
-| Canonical\* | When | What | Source (if needed) |
-| ----------- | ---- |------|--------------------|
-|    | July 2019 | [CDF faq defines continuous delivery](https://github.com/cdfoundation/faq#what-is-continuous-delivery-cd) | [cdfoundation/faq](https://github.com/cdfoundation/faq/commit/e1c2ea472284422ff300c948f13fb37de528d926)|
-|    | July 2013 | [Martin Fowler defines Continuous Delivery](https://www.martinfowler.com/bliki/ContinuousDelivery.html) ||
-| ⭐ | July 2010   | [Continuous Delivery by Jez Humble and David Farley](https://www.oreilly.com/library/view/continuous-delivery-reliable/9780321670250/) ||
-|    | Feb 2010 | [Continuous Delivery](https://continuousdelivery.com/2010/02/continuous-delivery/) ||
-| ⭐ | Feb 2009 | [Continuous Deployment](http://timothyfitz.com/2009/02/08/continuous-deployment/) ||
-| ⭐ | June 2007  | [Continuous Integration: Improving Software Quality and Reducing Risk](https://www.oreilly.com/library/view/continuous-integration-improving/9780321336385/) || 
-
+| Canonical\* | When | What | Terms | Source (if needed) |
+| ----------- | ---- | ---- | ----- |--------------------|
+|    | July 2019 | [CDF faq defines continuous delivery](https://github.com/cdfoundation/faq#what-is-continuous-delivery-cd) | Continuous Delivery, Continuous Integration | [cdfoundation/faq](https://github.com/cdfoundation/faq/commit/e1c2ea472284422ff300c948f13fb37de528d926)|
+|    | Dec 2016 | [First Wikipedia entry for CI/CD](https://en.wikipedia.org/w/index.php?title=CI/CD&oldid=756752283) | CI/CD | |
+|    | July 2014 | [Earliest article attempting to explain the origin of "CI/CD"](https://blogs.oracle.com/ravello/continuous-integration-deployment-test-automation) | CI/CD | |
+|    | 2014 | [CI/CD starts appearing as a search term](https://trends.google.com/trends/explore?date=all&q=ci%2Fcd) | CI/CD | |
+|    | July 2013 | [Martin Fowler defines Continuous Delivery](https://www.martinfowler.com/bliki/ContinuousDelivery.html) | Continuous Delivery ||
+| ⭐ | July 2010   | [Continuous Delivery by Jez Humble and David Farley](https://www.oreilly.com/library/view/continuous-delivery-reliable/9780321670250/) | Continuous Delivery, Continuous Integration |
+|    | Aug 2010 | [Continuous Delivery vs Continuous Deployment](https://continuousdelivery.com/2010/08/continuous-delivery-vs-continuous-deployment/) | Continuous Delivery, Continuous Deployment ||
+|    | Feb 2010 | [Continuous Delivery](https://continuousdelivery.com/2010/02/continuous-delivery/) | Continuous Delivery ||
+| ⭐ | Feb 2009 | [Continuous Deployment](http://timothyfitz.com/2009/02/08/continuous-deployment/) | Continuous Deployment ||
+| ⭐ | June 2007  | [Continuous Integration: Improving Software Quality and Reducing Risk](https://www.oreilly.com/library/view/continuous-integration-improving/9780321336385/) | Continuous Integration || 
+|    | Feb 2001 | [Principles behind the Agile Manifesto](http://agilemanifesto.org/principles.html) | Inspired Continuous Delivery | [History: The Agile Manifesto](https://agilemanifesto.org/history.html), [Continuous Delivery footnote](https://continuousdelivery.com/2010/02/continuous-delivery/#1)|
+|    | 1994 | [Object Oriented Analysis and Design with Applications](https://www.pearson.com/us/higher-education/program/Booch-Object-Oriented-Analysis-and-Design-with-Applications-3rd-Edition/PGM311798.html)| Continuous Integration | [A Brief History of DevOps, Part III](https://circleci.com/blog/a-brief-history-of-devops-part-iii-automated-testing-and-continuous-integration/) |


### PR DESCRIPTION
This commit adds:
* Some more history for CI (Grady Booch in 1994)
* Some guesses at the history of CI/CD (no one seemes to have set out to
  create this term intentionally)
* The Agile principles, since Jez Humble mentioned this as being the
  motivation behind the term "continuous delivery"

Also updated the table to indicate which terms each entry applies to

@salaboy @tracymiranda 