### PR TITLE
Add initial definitions for CD terms 📙

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 Reference repository composed of timelines, lists and various other informative items related to the field of continuous delivery
 
 * [Timeline](timeline.md)
+* [Definitions](definitions.md)

--- a/definitions.md
+++ b/definitions.md
@@ -1,0 +1,66 @@
+# Continuous Delivery Definitions
+
+The purpose of this doc is to record definitions of important terminology in the Continuous
+Delivery space, based on [the canonical definitions of these terms](timeline.md).
+
+This is meant to be a living document: if you would like to propose updates to these definitions,
+[please open a PR](CONTRIBUTING.md).
+
+* [Continuous Delivery](#continuous-delivery)
+* [Continuous Deployoment](#continuous-deployment)
+* [Continuous Integration](#continuous-integration)
+* [CI/CD](#cicd)
+
+## Continuous Delivery
+
+**Continuous Delivery (CD)**: A software development practice in which teams release software changes to users safely,
+quickly and sustainably by:
+
+ 1. Proving that changes can be released at any time
+ 2. Automating release processes
+
+Sources: [Continuous Delivery (2010)](https://www.oreilly.com/library/view/continuous-delivery-reliable/9780321670250/),
+[Martin Fowler](https://www.martinfowler.com/bliki/ContinuousDelivery.html),
+[Jez Humble](https://www.informit.com/articles/article.aspx?p=1833567&seqNum=2)
+
+How does Continuous Delivery relate to:
+* [Continuous Integration](#continuous-integration): Continuous Integration is a practice that makes Continuous Delivery
+  Possible - [Continuous Delivery (2010)](https://www.oreilly.com/library/view/continuous-delivery-reliable/9780321670250/)
+* [Continuous Deployment](#continuous-deployment): Continuous Deployment is made possible by Continuous Delivery -
+  [Jez Humble](https://continuousdelivery.com/2010/08/continuous-delivery-vs-continuous-deployment/),
+  [Timothy Fitz](https://www.blazemeter.com/blog/five-things-you-should-know-about-continuous-deploymentby-man-who-coined-term),
+  [Martin Fowler](https://martinfowler.com/bliki/ContinuousDelivery.html)
+
+## Continuous Deployment
+
+**Continuous Deployment**: Working software is released to users automatically on every commit.
+
+Sources: [Timothy Fitz](http://timothyfitz.com/2009/02/08/continuous-deployment/)
+
+How does Continuous Deployment relate to:
+* [Continuous Delivery](#continuous-delivery): Continuous Deployment is made possible by Continuous Delivery -
+  [Jez Humble](https://continuousdelivery.com/2010/08/continuous-delivery-vs-continuous-deployment/),
+  [Timothy Fitz](https://www.blazemeter.com/blog/five-things-you-should-know-about-continuous-deploymentby-man-who-coined-term),
+  [Martin Fowler](https://martinfowler.com/bliki/ContinuousDelivery.html)
+* [Continuous Integration](#continuous-integration): Continuous Integration is a requirement for Continuous Deployment -
+  [Timothy Fitz](http://timothyfitz.com/2012/11/25/paths-to-continuous-deployment/)
+
+## Continuous Integration
+
+**Continuous Integration (CI)**: The process of combining code changes frequently, where each change
+  is verified on check in.
+
+Sources: [Continuous Delivery (2010)](https://www.oreilly.com/library/view/continuous-delivery-reliable/9780321670250/),
+[Continuous Integration (2007)](https://martinfowler.com/books/duvall.html)
+
+## CI/CD
+
+**CI/CD**: A phrase with no clear origin which popped into existence around 2014, which combines
+[Continuous Integration (CI)](#continuous-integration] with either [Continuous Delivery (CD)](#continuous-delivery) or
+[Continuous Deployment](#continuous-deployment]. The phrase is used to refer to tools and practices which encompass one
+or more of: Continuous Integration, Continuous Delivery and Continuous Deployment.
+
+Sources: [Google trends](https://trends.google.com/trends/explore?date=all&q=ci%2Fcd),
+[First Wikipedia entry (Dec 2016)](https://en.wikipedia.org/w/index.php?title=CI/CD&oldid=756752283),
+[2014 article](https://blogs.oracle.com/ravello/continuous-integration-deployment-test-automation)
+

--- a/timeline.md
+++ b/timeline.md
@@ -1,10 +1,9 @@
 # Continuous Delivery Terminology Timeline
 
 The purpose of this doc is to record the timeline of when important terminology in
-the Continous Delivery came into being.
+the Continuous Delivery came into being.
 
-This is not meant to be the definitivie definitions of each of these terms (watch
-this repo!)
+See [definitions](definitions.md) for the CDF's definitions of these terms.
 
 This is meant to be a living document: if you have additional information on the
 origins of these phrases, [please open a PR](CONTRIBUTING.md)!
@@ -23,7 +22,7 @@ origins of these phrases, [please open a PR](CONTRIBUTING.md)!
 | ⭐ | July 2010   | [Continuous Delivery by Jez Humble and David Farley](https://www.oreilly.com/library/view/continuous-delivery-reliable/9780321670250/) | Continuous Delivery, Continuous Integration |
 |    | Aug 2010 | [Continuous Delivery vs Continuous Deployment](https://continuousdelivery.com/2010/08/continuous-delivery-vs-continuous-deployment/) | Continuous Delivery, Continuous Deployment ||
 |    | Feb 2010 | [Continuous Delivery](https://continuousdelivery.com/2010/02/continuous-delivery/) | Continuous Delivery ||
-|    | Nov 2009 | [The Origins of DevOps: What's in a Name?](https://devops.com/the-origins-of-devops-whats-in-a-name/) | DevOps | The first conference named devopsdays was held in Belgium, popularizing the term. [Source](https://devopsdays.org/blog/2009/11/11/devopsdays-2009-belgium-a-great-success/)|
+| ⭐ | Nov 2009 | [The Origins of DevOps: What's in a Name?](https://devops.com/the-origins-of-devops-whats-in-a-name/) | DevOps | The first conference named devopsdays was held in Belgium, popularizing the term. [Source](https://devopsdays.org/blog/2009/11/11/devopsdays-2009-belgium-a-great-success/)|
 | ⭐ | Feb 2009 | [Continuous Deployment](http://timothyfitz.com/2009/02/08/continuous-deployment/) | Continuous Deployment ||
 |    | June 2007  | [Continuous Integration: Improving Software Quality and Reducing Risk](https://www.oreilly.com/library/view/continuous-integration-improving/9780321336385/) | Continuous Integration ||
 |    | Feb 2001 | [Principles behind the Agile Manifesto](http://agilemanifesto.org/principles.html) | Inspired Continuous Delivery | [History: The Agile Manifesto](https://agilemanifesto.org/history.html), [Continuous Delivery footnote](https://continuousdelivery.com/2010/02/continuous-delivery/#1)|


### PR DESCRIPTION
The discussion about these definitions was kicked off in the
interoperability working group, then moved to
[this google doc](https://docs.google.com/document/d/1IUSmgtw5eC2JwyfiX7IPK3twl3MSjWAsmCKmJ6Y5z-w/edit#)
and now is being moved to this repo, after having established (at least
an initial) timeline in timeline.md of when these terms came into being.

This is intended to just be the first iteration of these defintions and
to be refined over time.

@tracymiranda @salaboy @tequilarista @fdegir 